### PR TITLE
Very long callback URL issue 

### DIFF
--- a/db/migrate/20151013155414_increase_callback_url_size.rb
+++ b/db/migrate/20151013155414_increase_callback_url_size.rb
@@ -1,0 +1,5 @@
+class IncreaseCallbackUrlSize < ActiveRecord::Migration
+  def change
+    change_column :oauth_tokens, :callback_url, :string, :limit => 2000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131114140501) do
+ActiveRecord::Schema.define(:version => 20151013155414) do
 
   create_table "client_applications", :force => true do |t|
     t.string   "name"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(:version => 20131114140501) do
     t.integer  "client_application_id"
     t.string   "token",                 :limit => 40
     t.string   "secret",                :limit => 40
-    t.string   "callback_url"
+    t.string   "callback_url",          :limit => 2000
     t.string   "verifier",              :limit => 20
     t.string   "scope"
     t.datetime "authorized_at"


### PR DESCRIPTION
Fix an issue where Cerberus crashed because of callback URL longuer than 255 char.
DB and data model changed to support callback URL until 2000 char max.